### PR TITLE
specify X11 dependency

### DIFF
--- a/Formula/gepetto-viewer.rb
+++ b/Formula/gepetto-viewer.rb
@@ -18,7 +18,7 @@ class GepettoViewer < Formula
   depends_on "gepetto/gepetto/open-scene-graph-with-colladadom"
   depends_on "urdfdom"
   depends_on "osgqt"
-  depends_on :x11
+  depends_on "xquartz"
 
   def install
     if build.head?


### PR DESCRIPTION
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/gepetto/homebrew-gepetto/Formula/gepetto-viewer.rb
gepetto-viewer: Calling depends_on :x11 is disabled! Use depends_on specific X11 formula(e) instead.
Please report this issue to the gepetto/gepetto tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/gepetto/homebrew-gepetto/Formula/gepetto-viewer.rb:21

Error: Cannot tap gepetto/gepetto: invalid syntax in tap!